### PR TITLE
Add sync and distill workflow

### DIFF
--- a/.github/workflows/synronize_scs_docs.yml
+++ b/.github/workflows/synronize_scs_docs.yml
@@ -31,10 +31,8 @@ jobs:
       matrix: 
         repos: ${{ fromJson(needs.provide_repos_json.outputs.matrix) }}
     steps: 
-      - name: set repos
-        run: |
-          echo ${{matrix.repos.name}}
-          printf $(pwd)
+      - name: checkout the docusaurus repo (B)
+        uses: actions/checkout@v3
   
       - name: clone repo A which is about to be synchronized
         uses: sudosubin/git-clone-action@v1.0.1

--- a/.github/workflows/synronize_scs_docs.yml
+++ b/.github/workflows/synronize_scs_docs.yml
@@ -31,9 +31,6 @@ jobs:
       matrix: 
         repos: ${{ fromJson(needs.provide_repos_json.outputs.matrix) }}
     steps: 
-      - name: checkout the docusaurus repo (B)
-        uses: actions/checkout@v3
-
       - name: set repos
         run: |
           echo ${{matrix.repos.name}}
@@ -56,7 +53,6 @@ jobs:
       - name: create docusaurus subdirectory
         run: |
           mkdir $(pwd)/docs/${{matrix.repos.name}} || true
-          printf $(pwd)
 
       - name: copy docs content from A to B
         run: |

--- a/.github/workflows/synronize_scs_docs.yml
+++ b/.github/workflows/synronize_scs_docs.yml
@@ -1,0 +1,81 @@
+---
+name: Synchronize SCS Docs
+
+"on":
+  push:
+    paths:
+    # only trigger the workflow when docs.json has been changed
+      - 'docs.json'
+    branches:
+      - main
+
+jobs:
+  provide_repos_json:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout the docusaurus repo (B)
+        uses: actions/checkout@v3
+
+      - name: Set Matrix
+        id: set-matrix
+        run: |
+          REPOS=$(echo $(cat ././docs.json) | sed 's/ //g' )
+          echo "::set-output name=matrix::$REPOS"
+  
+  sync_repos:
+    needs: provide_repos_json
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        repos: ${{ fromJson(needs.provide_repos_json.outputs.matrix) }}
+    steps: 
+      - name: checkout the docusaurus repo (B)
+        uses: actions/checkout@v3
+
+      - name: set repos
+        run: |
+          echo ${{matrix.repos.name}}
+          printf $(pwd)
+  
+      - name: clone repo A which is about to be synchronized
+        uses: sudosubin/git-clone-action@v1.0.1
+        with:
+          repository: ${{matrix.repos.org}}/${{matrix.repos.name}}
+          path: 'repo_to_be_edited'
+
+      - name: remove git folders from A
+        run: |
+          rm -rf $(pwd)/repo_to_be_edited/.git
+
+      - name: debug
+        run: ls -la repo_to_be_edited
+
+      - name: remove README.md files from A
+        run: |
+          find $(pwd)/repo_to_be_edited -name "README.md" | xargs rm -f
+
+      - name: create docusaurus subdirectory
+        run: |
+          mkdir $(pwd)/docs/${{matrix.repos.name}} || true
+          printf $(pwd)
+
+      - name: copy docs content from A to B
+        run: |
+          cp -r $(pwd)/repo_to_be_edited/docs/* $(pwd)/docs/${{matrix.repos.name}}
+          
+      - name: remove repo A
+        run: |
+          rm -rf $(pwd)/repo_to_be_edited/
+
+      - name: commit and push B
+        uses: EndBug/add-and-commit@v9
+        with:
+          author_name: 'bot@maxwolfs'
+          committer_name: Action Bot
+          commit: --signoff
+          message: "distill"
+          push: true
+          pull: --rebase --autostash
+          add: "docs"

--- a/.github/workflows/synronize_scs_docs.yml
+++ b/.github/workflows/synronize_scs_docs.yml
@@ -49,9 +49,6 @@ jobs:
         run: |
           rm -rf $(pwd)/repo_to_be_edited/.git
 
-      - name: debug
-        run: ls -la repo_to_be_edited
-
       - name: remove README.md files from A
         run: |
           find $(pwd)/repo_to_be_edited -name "README.md" | xargs rm -f

--- a/example.docs.json
+++ b/example.docs.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "openstack-image-manager",
+        "org": "osism"
+    },
+    {
+        "name": "testbed",
+        "org": "osism"
+    }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@docusaurus/core": "2.2.0",
         "@docusaurus/preset-classic": "2.2.0",


### PR DESCRIPTION
Signed-off-by: maxwolfs <mail@maxwolfs.com>

closes #1 

This adds the workflow for cloning and distilling the target repos into this repositories `/docs/${target-repo}` directory. This enables docusaurus to render only the needed markdown files.

The target repos have to be defined in the `docs.json` in the root direcotry for this repository. I have included an `example.docs.json`. The github action only triggers, if the `docs.json`has been changed.  The workflow consists of two jobs. The first action `provide_repos_json` reads the `docs.json` and converts it into a matrix strategy the second job `sync_repos` can read and run on for each element in the `docs.json`. The good thing about the JSON is also that it could be generated automatically in the future.

Once the first target repository – openstack-image-manager – is ready the `docs.json` can be added via a PR to trigger the first run.

Question: What do you think of the format within the `example.docs.json`? Should we include other information? What about the proposed naming of the keys?