### PR TITLE
Use dark theme for all codeblocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,6 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require('prism-react-renderer/themes/github')
 const darkCodeTheme = require('prism-react-renderer/themes/dracula')
 
 /** @type {import('@docusaurus/types').Config} */
@@ -128,7 +127,7 @@ const config = {
             copyright: 'Sovereign Cloud Stack, SCS and the logo are registered trademarks of the Open Source Business Alliance e.V. — Other trademarks are property of their respective owners.'
           },
           prism: {
-            theme: lightCodeTheme,
+            theme: darkCodeTheme,
             darkTheme: darkCodeTheme,
             additionalLanguages: ['powershell', 'ruby']
           }


### PR DESCRIPTION
Before:
<img width="1470" alt="Bildschirmfoto 2023-02-20 um 13 41 06" src="https://user-images.githubusercontent.com/28341836/220111174-c0a06777-d333-44b8-8a46-a8a8e2995908.png">


After:
<img width="1470" alt="Bildschirmfoto 2023-02-20 um 13 40 33" src="https://user-images.githubusercontent.com/28341836/220110948-d4a1dda3-2005-4804-8817-a1ae61f6e91e.png">
