### PR TITLE
Add custom matomo implementation enabling cookie settings

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,7 +54,7 @@ const config = {
         // ... other options
       }
     ],
-    'docusaurus-plugin-matomo'
+    './src/plugins/docusaurus-plugin-matomo-analytics/index.js'
   ],
 
   themeConfig:
@@ -133,11 +133,13 @@ const config = {
             darkTheme: darkCodeTheme,
             additionalLanguages: ['powershell', 'ruby']
           },
-          matomo: {
-            matomoUrl: 'https://matomo.scs.community/',
+          matomoAnalytics: {
+            matomoUrl:
+              'matomo.scs.community',
             siteId: '2',
             phpLoader: 'matomo.php',
-            jsLoader: 'matomo.js'
+            jsLoader: 'matomo.js',
+            disableCookies: true
           }
         }),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@fullcalendar/timegrid": "^6.0.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
-        "docusaurus-plugin-matomo": "^0.0.6",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -6123,17 +6122,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/docusaurus-plugin-matomo": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-matomo/-/docusaurus-plugin-matomo-0.0.6.tgz",
-      "integrity": "sha512-zAhUz3eMaW2tUJsvV5guOMwb554swoVEeI55BZA10LVk3+PyfWYpBl2FEHITe0ofA8/vG6BTuTzGNSWxW70NwA==",
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/core": "^2.0.0-alpha.56"
       }
     },
     "node_modules/dom-converter": {
@@ -18860,12 +18848,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "docusaurus-plugin-matomo": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-matomo/-/docusaurus-plugin-matomo-0.0.6.tgz",
-      "integrity": "sha512-zAhUz3eMaW2tUJsvV5guOMwb554swoVEeI55BZA10LVk3+PyfWYpBl2FEHITe0ofA8/vG6BTuTzGNSWxW70NwA==",
-      "requires": {}
     },
     "dom-converter": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@fullcalendar/timegrid": "^6.0.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
-    "docusaurus-plugin-matomo": "^0.0.6",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/plugins/docusaurus-plugin-matomo-analytics/index.js
+++ b/src/plugins/docusaurus-plugin-matomo-analytics/index.js
@@ -1,0 +1,78 @@
+const path = require('path')
+
+// based on https://github.com/karser/docusaurus-plugin-matomo with extended parameters
+
+function matomoAnalytics (context, options) {
+  const { siteConfig } = context
+  const { themeConfig } = siteConfig
+  const { matomoAnalytics } = themeConfig || {}
+
+  if (!matomoAnalytics) {
+    throw new Error(
+      'Please specify \'matomo\' object in \'themeConfig\' with \'matomoUrl\' and \'siteId\' fields in it to use docusaurus-plugin-matomo'
+    )
+  }
+
+  const { matomoUrl, siteId } = matomoAnalytics
+
+  if (!matomoUrl) {
+    throw new Error(
+      'Please specify the `matomoUrl` field in the `themeConfig.matomo`'
+    )
+  }
+  if (!siteId) {
+    throw new Error(
+      'Please specify the `siteId` field in the `themeConfig.matomo`'
+    )
+  }
+
+  const isProd = process.env.NODE_ENV === 'production'
+  return {
+    name: 'docusaurus-plugin-matomo-analytics',
+
+    getClientModules () {
+      return isProd ? [path.resolve(__dirname, './track')] : []
+    },
+
+    injectHtmlTags () {
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'preconnect',
+              href: `${matomoAnalytics.matomoUrl}`
+            }
+          },
+          {
+            tagName: 'script',
+            innerHTML: `
+                var _paq = window._paq = window._paq || [];
+                _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+                ${matomoAnalytics.cookieDomain ? `_paq.push(["setCookieDomain", "${matomoAnalytics.cookieDomain}"]);` : ''}
+                ${matomoAnalytics.domains ? `_paq.push(["setDomains", ["${matomoAnalytics.domains}"]])` : ''}
+                ${matomoAnalytics.campaignNameKey ? `_paq.push(["setCampaignNameKey", "${matomoAnalytics.campaignNameKey}"]);` : ''}
+                ${matomoAnalytics.campaignKeywordKey ? `_paq.push(["setCampaignKeywordKey", "${matomoAnalytics.campaignKeywordKey}"]);` : ''}
+                ${matomoAnalytics.doNotTrack ? `_paq.push(["setDoNotTrack", ${matomoAnalytics.doNotTrack}]);` : ''}
+                ${matomoAnalytics.disableCookies ? '_paq.push(["disableCookies"]);' : ''}
+                _paq.push(['trackPageView']);
+                _paq.push(['enableLinkTracking']);
+                    (function() {
+                        var u="${matomoAnalytics.matomoUrl}";
+                        _paq.push(['setTrackerUrl', u+'${matomoAnalytics.phpLoader}']);
+                        _paq.push(['setSiteId', '${matomoAnalytics.siteId}']);
+                        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                        g.async=true; g.src=u+'${
+                            matomoAnalytics.jsLoader
+                        }'; s.parentNode.insertBefore(g,s);
+                    })();
+
+            `
+          }
+        ]
+      }
+    }
+  }
+}
+
+module.exports = matomoAnalytics

--- a/src/plugins/docusaurus-plugin-matomo-analytics/track.js
+++ b/src/plugins/docusaurus-plugin-matomo-analytics/track.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-undef */
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment'
+
+export default (function () {
+  if (!ExecutionEnvironment.canUseDOM) {
+    return null
+  }
+  return {
+    onRouteUpdate ({ location }) {
+      _paq.push(['setCustomUrl', location.pathname])
+      _paq.push(['setDocumentTitle', document.title])
+      _paq.push(['trackPageView'])
+    }
+  }
+})()


### PR DESCRIPTION
closes #46

Output from <head ><script>...</script> on https://docs-staging.scs.community/

```js
var _paq = window._paq = window._paq || [];
	_paq.push(["setDocumentTitle", document.domain + "/" + document.title]), 
	_paq.push(["disableCookies"]), 
    _paq.push(["trackPageView"]), 
    _paq.push(["enableLinkTracking"]),
    function() {
        var e = "matomo.scs.community";
        _paq.push(["setTrackerUrl", e + "matomo.php"]), _paq.push(["setSiteId", "2"]);
        var a = document,
            t = a.createElement("script"),
            p = a.getElementsByTagName("script")[0];
        t.async = !0, t.src = e + "matomo.js", p.parentNode.insertBefore(t, p)
    }()
```